### PR TITLE
custom event cleanup and improvements

### DIFF
--- a/tools/integration/src/index.ts
+++ b/tools/integration/src/index.ts
@@ -117,8 +117,8 @@ const examplesForExport = `
 Examples:
 
 Export integration elements:
-  ${execName} export --server example.com --include 'type=dashboard title="Runtime.*"' --location ./my-package
-  ${execName} export --server example.com --include 'type=event id=exampleid' --location ./my-package
+  ${execName} export --server example.com --include type=dashboard title="Runtime.*" --location ./my-package
+  ${execName} export --server example.com --include type=event id=exampleid --location ./my-package
 `;
 
 // Configure yargs to parse command-line arguments with subcommands
@@ -712,7 +712,7 @@ async function handleImport(argv: any) {
         })
     });
 
-    async function importIntegration(searchPattern: string, apiPath: string) {
+    async function importIntegration(searchPattern: string, apiPath: string, typeLabel: string) {
         const files = globSync(searchPattern);
 
         logger.info(`Start to import the integration package from ${searchPattern}`);
@@ -758,22 +758,14 @@ async function handleImport(argv: any) {
 
                 try {
                     const url = `https://${server}/${apiPath}`;
-
-                    function getTypeLabel(apiPath: String): String {
-		    	if(apiPath.includes('custom-dashboard')) return 'custom dashboard';
-			if(apiPath.includes('event-specifications')) return 'custom event';
-			return 'custom element';
-		    }
-		    const typeLabel = getTypeLabel(apiPath);
-		    logger.info(`Applying the ${typeLabel} to ${url} ...`);
-
+                    logger.info(`Applying the ${typeLabel} to ${url} ...`);
                     const response = await axiosInstance.post(url, jsonContent, {
                         headers: {
                             'Content-Type': 'application/json',
                             'Authorization': `apiToken ${token}`
-                        }
+			}
                     });
-                    logger.info(`Successfully applied ${file}: ${response.status}`);
+		    logger.info(`Successfully applied ${file}: ${response.status}`);
                 } catch (error) {
                     if (axios.isAxiosError(error)) {
                         logger.error(`Failed to apply ${file}: ${error.message}`);
@@ -795,18 +787,18 @@ async function handleImport(argv: any) {
     if (includePattern) {
         const searchPattern = path.join(packagePath, includePattern);
         if (includePattern.includes('events')) {
-            await importIntegration(searchPattern, "api/events/settings/event-specifications/custom");
+            await importIntegration(searchPattern, "api/events/settings/event-specifications/custom", "custom event");
         } else {
-            await importIntegration(searchPattern, "api/custom-dashboard");
+            await importIntegration(searchPattern, "api/custom-dashboard", "custom dashboard");
         }
     } else {
         for (const defaultFolder of defaultFolders) {
             const searchPattern = path.join(packagePath, defaultFolder, '**/*.json');
-            await importIntegration(searchPattern, "api/custom-dashboard");
+            await importIntegration(searchPattern, "api/custom-dashboard", "custom dashboard");
         }
         for (const defaultFolder of defaultEventsFolders) {
             const searchPattern = path.join(packagePath, defaultFolder, '**/*.json');
-            await importIntegration(searchPattern, "api/events/settings/event-specifications/custom");
+            await importIntegration(searchPattern, "api/events/settings/event-specifications/custom", "custom event");
         }
     }
 }
@@ -825,17 +817,7 @@ async function handleExport(argv: any) {
         })
     });
 
-    const includes = Array.isArray(includeRaw) ? includeRaw : (includeRaw ? [includeRaw] : []);
-    const parsedIncludes = includes.map(item => {
-        const parts = parseIncludeItem(item);
-        const typePart = parts.find((p: string) => p.startsWith("type="));
-        const type = typePart ? typePart.split("=")[1] : "all";
-        const conditions = parts.filter((p: string) => !p.startsWith("type="));
-        if (!typePart) {
-            logger.warn(`'type=' missing in include clause "${item}", interpreting as type=all`);
-        }
-        return { type, conditions, explicitlyTyped: !!typePart };
-    });
+    const parsedIncludes = parseIncludesFromArgv(process.argv);
 
     const dashboardsPath = path.join(location, "dashboards");
     const eventsPath = path.join(location, "events");
@@ -854,15 +836,11 @@ async function handleExport(argv: any) {
             const matches = inc.conditions.filter(c => c.startsWith("id="));
 
             let filtered;
-            if (matches.length && inc.explicitlyTyped) {
+            if (matches.length) {
                 filtered = matches.map(idCond => {
                     const id = idCond.split("=")[1]?.replace(/^"|"$/g, '');
-                    return { id };
-                });
-            } else if (matches.length) {
-                filtered = matches.map(idCond => {
-                    const id = idCond.split("=")[1]?.replace(/^"|"$/g, '');
-                    return allDashboards.find(d => d.id === id);
+                    const found = allDashboards.find(d => d.id === id);
+                    return found;
                 }).filter(Boolean);
             } else {
                 filtered = filterDashboardsBy(allDashboards, inc.conditions);
@@ -903,15 +881,11 @@ async function handleExport(argv: any) {
             const matches = inc.conditions.filter(c => c.startsWith("id="));
 
             let filtered;
-            if (matches.length && inc.explicitlyTyped) {
+	    if (matches.length) {
                 filtered = matches.map(idCond => {
                     const id = idCond.split("=")[1]?.replace(/^"|"$/g, '');
-                    return { id };
-                });
-            } else if (matches.length) {
-                filtered = matches.map(idCond => {
-                    const id = idCond.split("=")[1]?.replace(/^"|"$/g, '');
-                    return allEvents.find(e => e.id === id);
+                    const found = allEvents.find(e => e.id === id);
+                    return found;
                 }).filter(Boolean);
             } else {
                 filtered = filterEventsBy(allEvents, inc.conditions);
@@ -944,15 +918,10 @@ async function handleExport(argv: any) {
     }
 
     // Final info
-    const isOnlyDashboard = parsedIncludes.every(inc => inc.type === "dashboard");
-    const isOnlyEvent = parsedIncludes.every(inc => inc.type === "event");
-    const isMixedOrUnspecified = parsedIncludes.some(inc => inc.type === "all") || (!isOnlyDashboard && !isOnlyEvent);
-
-    if (!wasDashboardFound && !wasEventFound && isMixedOrUnspecified) {
+    if (!wasDashboardFound && !wasEventFound) {
         logger.error("No custom elements were found or exported.");
     }
 }
-
 
 // Helper functions for dashboard export
 async function exportDashboard(server: string, token: string, dashboardId: string, axiosInstance: any): Promise<any> {
@@ -1110,6 +1079,40 @@ function filterEventsBy(idObjects: any[], include: string[]): any[] {
 }
 
 // Helpers for export
+function parseIncludesFromArgv(argv: string[]): { type: string, conditions: string[], explicitlyTyped: boolean }[] {
+  const includes: { type: string, conditions: string[], explicitlyTyped: boolean }[] = [];
+  let current: { type: string, conditions: string[], explicitlyTyped: boolean } | null = null;
+  let clauseParts: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--include") {
+      if (clauseParts.length && !current?.explicitlyTyped) {
+        logger.warn(`'type=' missing in include clause "${clauseParts.join(" ")}", interpreting as type=all`);
+      }
+      clauseParts = [];
+      const next = argv[i + 1];
+      const keyVal = next?.split("=");
+      if (keyVal?.[0] === "type") {
+        current = { type: keyVal[1], conditions: [], explicitlyTyped: true };
+        i++;
+        clauseParts.push(`type=${keyVal[1]}`);
+      } else {
+        current = { type: "all", conditions: [], explicitlyTyped: false };
+      }
+      includes.push(current);
+    } else if (current) {
+      current.conditions.push(arg);
+      clauseParts.push(arg);
+    }
+  }
+
+  if (clauseParts.length && !current?.explicitlyTyped) {
+    logger.warn(`'type=' missing in include clause "${clauseParts.join(" ")}", interpreting as type=all`);
+  }
+  return includes;
+}
+
 function parseIncludeItem(item: string): string[] {
     const result: string[] = [];
     let buffer = '';

--- a/tools/integration/src/index.ts
+++ b/tools/integration/src/index.ts
@@ -289,7 +289,7 @@ async function handleLint(argv: any) {
     const dashboardsPath = path.join(currentDirectory, 'dashboards');
     const eventsPath = path.join(currentDirectory, 'events');
 
-    // Check README file
+    // Check README
     if (readmeContent) {
 	try {
 	    validateReadmeContent(readmeContent, packageData.name, currentDirectory, errors, warnings, successMessages);
@@ -404,7 +404,7 @@ async function validatePackageJson(packageData: any, errors: string[], warnings:
                 errors.push(`The package is missing required field ${field}.`);
             }
         } else {
-            successMessages.push(`The package ${field} is present.`);
+            successMessages.push(`The package field ${field} is present.`);
         }
     }
 
@@ -509,10 +509,10 @@ function validateEventFiles(eventsPath: string, errors: string[], warnings: stri
 
 	    // check rules are not empty
             if (event.rules.length === 0) {
-            	errors.push(`The rules array is empty in file: ${file}.`);
+            	errors.push(`The event rules array is empty in file: ${file}.`);
                 allEventFieldsValid = false;
             } else if (event.rules.some((rule: object) => Object.keys(rule).length === 0)) {
-		errors.push(`No rules are defined in: ${file}.`);
+		errors.push(`No event rules are defined in: ${file}.`);
                 allEventFieldsValid = false;
             }
 
@@ -749,8 +749,15 @@ async function handleImport(argv: any) {
                 }
 
                 try {
-                    const url = `https://${server}/${apiPath}`
-                    logger.info(`Applying the dashboard to ${url} ...`);
+                    const url = `https://${server}/${apiPath}`;
+
+                    function getTypeLabel(apiPath: String): String {
+		    	if(apiPath.includes('custom-dashboard')) return 'custom dashboard';
+			if(apiPath.includes('event-specifications')) return 'custom event';
+			return 'custom element';
+		    }
+		    const typeLabel = getTypeLabel(apiPath);
+		    logger.info(`Applying the ${typeLabel} to ${url} ...`);
 
                     const response = await axiosInstance.post(url, jsonContent, {
                         headers: {
@@ -815,74 +822,129 @@ async function handleExport(argv: any) {
         const parts = parseIncludeItem(item);
         const typePart = parts.find((p: string) => p.startsWith("type="));
         const type = typePart ? typePart.split("=")[1] : "all";
-
         const conditions = parts.filter((p: string) => !p.startsWith("type="));
         if (!typePart) {
             logger.warn(`'type=' missing in include clause "${item}", interpreting as type=all`);
         }
-
-        return { type, conditions };
+        return { type, conditions, explicitlyTyped: !!typePart };
     });
-
-    const dashboardIncludes = parsedIncludes
-        .filter(inc => inc.type === "dashboard" || inc.type === "all")
-        .flatMap(inc => inc.conditions);
-
-    const eventIncludes = parsedIncludes
-        .filter(inc => inc.type === "event" || inc.type === "all")
-        .flatMap(inc => inc.conditions);
 
     const dashboardsPath = path.join(location, "dashboards");
     const eventsPath = path.join(location, "events");
     fs.mkdirSync(dashboardsPath, { recursive: true });
     fs.mkdirSync(eventsPath, { recursive: true });
 
-    // Dashboard export
-    const dashboardId = getValueByKeyFromArray(dashboardIncludes, "id");
+    let wasDashboardFound = false;
+    let wasEventFound = false;
 
-    if (parsedIncludes.some(inc => inc.type === "dashboard")) {
-        if (dashboardId) {
-            const dashboard = await exportDashboard(server, token, dashboardId, axiosInstance);
-            if (dashboard) {
-                saveDashboard(dashboardsPath, dashboardId, sanitizeFileName(dashboard.title), dashboard);
+    // Dashboard export
+    if (parsedIncludes.some(inc => inc.type === "dashboard" || inc.type === "all")) {
+        const allDashboards = await getDashboardList(server, token, axiosInstance);
+        let totalDashboardProcessed = 0;
+
+        for (const inc of parsedIncludes.filter(inc => inc.type === "dashboard" || inc.type === "all")) {
+            const matches = inc.conditions.filter(c => c.startsWith("id="));
+
+            let filtered;
+            if (matches.length && inc.explicitlyTyped) {
+                filtered = matches.map(idCond => {
+                    const id = idCond.split("=")[1]?.replace(/^"|"$/g, '');
+                    return { id };
+                });
+            } else if (matches.length) {
+                filtered = matches.map(idCond => {
+                    const id = idCond.split("=")[1]?.replace(/^"|"$/g, '');
+                    return allDashboards.find(d => d.id === id);
+                }).filter(Boolean);
+            } else {
+                filtered = filterDashboardsBy(allDashboards, inc.conditions);
             }
-        } else {
-            const idObjects = await getDashboardList(server, token, axiosInstance);
-            const filtered = filterDashboardsBy(idObjects, dashboardIncludes);
+
+            if (filtered.length === 0) {
+                const logFn = inc.explicitlyTyped ? logger.error : logger.debug;
+                logFn(`No custom dashboard(s) found matching: ${inc.conditions.join(', ')}`);
+                continue;
+            }
+		const enriched = filtered.map(item => ({
+            	...item,
+                name: item.name ?? `custom-dashboard-${item.id}`
+            }));
             const sanitized = sanitizeTitles(filtered, "custom-dashboard");
-            for (const obj of sanitized) {
-                const dashboard = await exportDashboard(server, token, obj.id, axiosInstance);
+            for (const dash of sanitized) {
+                const dashboard = await exportDashboard(server, token, dash.id, axiosInstance);
                 if (dashboard) {
-                    saveDashboard(dashboardsPath, obj.id, obj.title, dashboard);
+                    saveDashboard(dashboardsPath, dash.id, dash.title, dashboard);
+                    totalDashboardProcessed++;
+                    wasDashboardFound = true;
+                } else {
+                    const logFn = inc.explicitlyTyped ? logger.error : logger.debug;
+                    logFn(`Dashboard with id=${dash.id} not found or failed to export.`);
                 }
             }
-            logger.info(`Total custom dashboard(s) processed: ${sanitized.length}`);
         }
+
+        logger.info(`Total custom dashboard(s) processed: ${totalDashboardProcessed}`);
     }
 
     // Event export
-    const eventId = getValueByKeyFromArray(eventIncludes, "id");
+    if (parsedIncludes.some(inc => inc.type === "event" || inc.type === "all")) {
+        const allEvents = await getEventList(server, token, axiosInstance);
+        let totalEventProcessed = 0;
 
-    if (parsedIncludes.some(inc => inc.type === "event")) {
-        if (eventId) {
-            const event = await exportEvent(server, token, eventId, axiosInstance);
-            if (event) {
-                saveEvent(eventsPath, eventId, sanitizeFileName(event.title || `event-${eventId}`), event);
+        for (const inc of parsedIncludes.filter(inc => inc.type === "event" || inc.type === "all")) {
+            const matches = inc.conditions.filter(c => c.startsWith("id="));
+
+            let filtered;
+            if (matches.length && inc.explicitlyTyped) {
+                filtered = matches.map(idCond => {
+                    const id = idCond.split("=")[1]?.replace(/^"|"$/g, '');
+                    return { id };
+                });
+            } else if (matches.length) {
+                filtered = matches.map(idCond => {
+                    const id = idCond.split("=")[1]?.replace(/^"|"$/g, '');
+                    return allEvents.find(e => e.id === id);
+                }).filter(Boolean);
+            } else {
+                filtered = filterEventsBy(allEvents, inc.conditions);
             }
-        } else {
-            const allEvents = await getEventList(server, token, axiosInstance);
-            const filtered = filterEventsBy(allEvents, eventIncludes);
+
+            if (filtered.length === 0) {
+                const logFn = inc.explicitlyTyped ? logger.error : logger.debug;
+                logFn(`No custom event(s) found matching: ${inc.conditions.join(', ')}`);
+                continue;
+            }
+		const enriched = filtered.map(item => ({
+                ...item,
+                name: item.name ?? `custom-event-${item.id}`
+            }));
             const sanitized = sanitizeTitles(filtered, "custom-event");
             for (const evt of sanitized) {
                 const event = await exportEvent(server, token, evt.id, axiosInstance);
                 if (event) {
                     saveEvent(eventsPath, evt.id, evt.title, event);
+                    totalEventProcessed++;
+                    wasEventFound = true;
+                } else {
+                    const logFn = inc.explicitlyTyped ? logger.error : logger.debug;
+                    logFn(`Event with id=${evt.id} not found or failed to export.`);
                 }
             }
-            logger.info(`Total custom event(s) processed: ${sanitized.length}`);
         }
+
+        logger.info(`Total custom event(s) processed: ${totalEventProcessed}`);
+    }
+
+    // Final info
+    const isOnlyDashboard = parsedIncludes.every(inc => inc.type === "dashboard");
+    const isOnlyEvent = parsedIncludes.every(inc => inc.type === "event");
+    const isMixedOrUnspecified = parsedIncludes.some(inc => inc.type === "all") || (!isOnlyDashboard && !isOnlyEvent);
+
+    if (!wasDashboardFound && !wasEventFound && isMixedOrUnspecified) {
+        logger.error("No custom elements were found or exported.");
     }
 }
+
 
 // Helper functions for dashboard export
 async function exportDashboard(server: string, token: string, dashboardId: string, axiosInstance: any): Promise<any> {
@@ -1244,7 +1306,7 @@ function generateReadme(packagePath: string, packageName: string, configTypes: s
 Below are the dashboards that are currently supported by this integration package.
 
 (Note: Below are the sample dashboards. Please replace these with your own actual dashboards.)
-| Dashboard Title    | Description                    |
+| Dashboard Title    | Description           |
 |--------------------|-----------------------|
 | Runtime Metrics    | Instana custom dashboard that displays runtime metrics for application |
 `;

--- a/tools/integration/src/index.ts
+++ b/tools/integration/src/index.ts
@@ -304,12 +304,12 @@ async function handleLint(argv: any) {
 	const strictMode = argv['strict-mode'];
         await validatePackageJson(packageData, errors, warnings, successMessages, strictMode);
         if(fs.existsSync(dashboardsPath)){
-        	validateDashboardFiles(dashboardsPath, errors, warnings, successMessages);
+            validateDashboardFiles(dashboardsPath, errors, warnings, successMessages);
         } else {
-        	logger.info('No dashboards folder found for this package.');
+            logger.info('No dashboards folder found for this package.');
         }
         if(fs.existsSync(eventsPath)){
-        	validateEventFiles(eventsPath, errors, warnings, successMessages);
+            validateEventFiles(eventsPath, errors, warnings, successMessages);
         } else {
             logger.info('No events folder found for this package.');
         }
@@ -541,7 +541,15 @@ function validateReadmeContent(readmeContent: string, packageName: string, curre
     if(eventsExist){
 	requiredSections.push('Events');
     }
-    const missingSections = requiredSections.filter(section => !readmeContent.includes(section));
+    const readmeLines = readmeContent.split('\n');
+    const headingLines = readmeLines
+        .filter(line => /^#{1,6}\s+/.test(line.trim()))
+        .map(line => line.trim().replace(/^#{1,6}\s+/, '').trim());
+
+    const missingSections = requiredSections.filter(section =>
+        !headingLines.some(heading => heading.toLowerCase() === section.toLowerCase())
+    );
+
     if (missingSections.length > 0) {
         errors.push(`README.md is missing required sections: ${missingSections.join(', ')}`);
     } else {
@@ -865,8 +873,8 @@ async function handleExport(argv: any) {
                 logFn(`No custom dashboard(s) found matching: ${inc.conditions.join(', ')}`);
                 continue;
             }
-		const enriched = filtered.map(item => ({
-            	...item,
+	    const enriched = filtered.map(item => ({
+                ...item,
                 name: item.name ?? `custom-dashboard-${item.id}`
             }));
             const sanitized = sanitizeTitles(filtered, "custom-dashboard");
@@ -914,7 +922,7 @@ async function handleExport(argv: any) {
                 logFn(`No custom event(s) found matching: ${inc.conditions.join(', ')}`);
                 continue;
             }
-		const enriched = filtered.map(item => ({
+	    const enriched = filtered.map(item => ({
                 ...item,
                 name: item.name ?? `custom-event-${item.id}`
             }));
@@ -1025,33 +1033,6 @@ function filterDashboardsBy(idObjects: IdObject[], include: string[]): IdObject[
 }
 
 // Helper functions for event export
-function parseIncludeItem(item: string): string[] {
-    const result: string[] = [];
-    let buffer = '';
-    let inQuotes = false;
-
-    for (let i = 0; i < item.length; i++) {
-        const char = item[i];
-
-        if (char === '"') {
-            inQuotes = !inQuotes;
-        } else if (char === ' ' && !inQuotes) {
-            if (buffer.length > 0) {
-                result.push(buffer);
-                buffer = '';
-            }
-        } else {
-            buffer += char;
-        }
-    }
-
-    if (buffer.length > 0) {
-        result.push(buffer);
-    }
-
-    return result;
-}
-
 async function exportEvent(server: string, token: string, eventId: string, axiosInstance: any): Promise<any> {
     try {
         const url = `https://${server}/api/events/settings/event-specifications/custom/${eventId}`;
@@ -1129,6 +1110,33 @@ function filterEventsBy(idObjects: any[], include: string[]): any[] {
 }
 
 // Helpers for export
+function parseIncludeItem(item: string): string[] {
+    const result: string[] = [];
+    let buffer = '';
+    let inQuotes = false;
+
+    for (let i = 0; i < item.length; i++) {
+        const char = item[i];
+
+        if (char === '"') {
+            inQuotes = !inQuotes;
+        } else if (char === ' ' && !inQuotes) {
+            if (buffer.length > 0) {
+                result.push(buffer);
+                buffer = '';
+            }
+        } else {
+            buffer += char;
+        }
+    }
+
+    if (buffer.length > 0) {
+        result.push(buffer);
+    }
+
+    return result;
+}
+
 function sanitizeFileName(name: string): string {
     if (!name) return 'untitled'; // fallback
     return name.replace(/[^a-z0-9-_]/gi, '_').toLowerCase();


### PR DESCRIPTION
This PR addresses feedback from the previous PR and implements several cleanup and improvement points.

Changes Included
* Removed the need for quoting --include values in the export command to simplify CLI usage.
* Passed the type label directly to importIntegration instead of inferring it from apiPath.
* Simplified export summary logic by relying only on the count of processed items.
* Replaced separate code paths for typed and untyped includes by always checking if the event ID exists in the list before using it. 