### PR TITLE
stanctl-fleet: list command

### DIFF
--- a/tools/fleet/src/__tests__/cli.test.ts
+++ b/tools/fleet/src/__tests__/cli.test.ts
@@ -77,7 +77,7 @@ describe('CLI Module', () => {
             expect(cliContent).toContain('Restart the agent instances');
             expect(cliContent).toContain('Deploy the agent component');
             expect(cliContent).toContain('Update the agent configuration');
-            expect(cliContent).toContain('list available resources');
+            expect(cliContent).toContain('List available resources');
         });
 
         it('should configure yargs with proper settings', async () => {

--- a/tools/fleet/src/__tests__/cli.test.ts
+++ b/tools/fleet/src/__tests__/cli.test.ts
@@ -54,6 +54,7 @@ describe('CLI Module', () => {
             expect(cliContent).toContain('examplesForRestart');
             expect(cliContent).toContain('examplesForDeploy');
             expect(cliContent).toContain('examplesForUpdate');
+            expect(cliContent).toContain('examplesForList');
             expect(cliContent).toContain('Examples:');
         });
 
@@ -65,6 +66,7 @@ describe('CLI Module', () => {
             expect(cliContent).toContain("'restart'");
             expect(cliContent).toContain("'deploy'");
             expect(cliContent).toContain("'config-update'");
+            expect(cliContent).toContain("'list'");
         });
 
         it('should define command descriptions', async () => {
@@ -75,6 +77,7 @@ describe('CLI Module', () => {
             expect(cliContent).toContain('Restart the agent instances');
             expect(cliContent).toContain('Deploy the agent component');
             expect(cliContent).toContain('Update the agent configuration');
+            expect(cliContent).toContain('list available resources');
         });
 
         it('should configure yargs with proper settings', async () => {
@@ -114,6 +117,15 @@ describe('CLI Module', () => {
             expect(cliContent).toContain("'configuration-id'");
         });
 
+        it('should define resource option for list command', async () => {
+            const fs = require('fs');
+            const path = require('path');
+            const cliContent = fs.readFileSync(path.join(__dirname, '../cli.ts'), 'utf-8');
+
+            expect(cliContent).toContain("'resource'");
+            expect(cliContent).toContain("choices: ['configuration']");
+        });
+
         it('should mark --tag as required for restart', async () => {
             const fs = require('fs');
             const path = require('path');
@@ -132,6 +144,7 @@ describe('CLI Module', () => {
             expect(cliContent).toContain('handlers.handleRestart');
             expect(cliContent).toContain('handlers.handleDeploy');
             expect(cliContent).toContain('handlers.handleUpdate');
+            expect(cliContent).toContain('handlers.handleList');
         });
 
         it('should define all handler parameter types', async () => {
@@ -142,6 +155,7 @@ describe('CLI Module', () => {
             expect(cliContent).toContain('handleRestart: (argv: any) => Promise<void>');
             expect(cliContent).toContain('handleDeploy: (argv: any) => Promise<void>');
             expect(cliContent).toContain('handleUpdate: (argv: any) => Promise<void>');
+            expect(cliContent).toContain('handleList: (argv: any) => Promise<void>');
         });
     });
 
@@ -175,6 +189,7 @@ describe('CLI Module', () => {
             expect(cliContent).toContain('.epilog(examplesForRestart)');
             expect(cliContent).toContain('.epilog(examplesForDeploy)');
             expect(cliContent).toContain('.epilog(examplesForUpdate)');
+            expect(cliContent).toContain('.epilog(examplesForList)');
         });
 
         it('should set help and version aliases', async () => {

--- a/tools/fleet/src/__tests__/cli.test.ts
+++ b/tools/fleet/src/__tests__/cli.test.ts
@@ -66,7 +66,7 @@ describe('CLI Module', () => {
             expect(cliContent).toContain("'restart'");
             expect(cliContent).toContain("'deploy'");
             expect(cliContent).toContain("'update-config'");
-            expect(cliContent).toContain("'list'");
+            expect(cliContent).toContain("'list-configs'");
         });
 
         it('should define command descriptions', async () => {
@@ -77,7 +77,7 @@ describe('CLI Module', () => {
             expect(cliContent).toContain('Restart the agent instances');
             expect(cliContent).toContain('Deploy the agent component');
             expect(cliContent).toContain('Update the agent configuration');
-            expect(cliContent).toContain('List available resources');
+            expect(cliContent).toContain('List configurations');
         });
 
         it('should configure yargs with proper settings', async () => {
@@ -115,15 +115,6 @@ describe('CLI Module', () => {
             const cliContent = fs.readFileSync(path.join(__dirname, '../cli.ts'), 'utf-8');
 
             expect(cliContent).toContain("'configuration-id'");
-        });
-
-        it('should define resource option for list command', async () => {
-            const fs = require('fs');
-            const path = require('path');
-            const cliContent = fs.readFileSync(path.join(__dirname, '../cli.ts'), 'utf-8');
-
-            expect(cliContent).toContain("'resource'");
-            expect(cliContent).toContain("choices: ['configuration']");
         });
 
         it('should mark --tag as required for restart', async () => {

--- a/tools/fleet/src/__tests__/cli.test.ts
+++ b/tools/fleet/src/__tests__/cli.test.ts
@@ -65,7 +65,7 @@ describe('CLI Module', () => {
 
             expect(cliContent).toContain("'restart'");
             expect(cliContent).toContain("'deploy'");
-            expect(cliContent).toContain("'config-update'");
+            expect(cliContent).toContain("'update-config'");
             expect(cliContent).toContain("'list'");
         });
 

--- a/tools/fleet/src/__tests__/handlers/list.test.ts
+++ b/tools/fleet/src/__tests__/handlers/list.test.ts
@@ -17,7 +17,6 @@ describe('handleList', () => {
         server: 'localhost:8080',
         token: 'test-token',
         type: 'com.ibm.instana.customcollector',
-        resource: 'configuration',
         debug: false
     };
 
@@ -53,7 +52,7 @@ describe('handleList', () => {
         });
         mockedAxios.create.mockReturnValue({ get: getMock } as any);
 
-        const argv = { type: baseArgv.type, resource: 'configuration', debug: false };
+        const argv = { type: baseArgv.type, debug: false };
         const result = await handleList(argv);
 
         expect(result).toEqual([{ id: 'cfg-2' }]);
@@ -63,7 +62,7 @@ describe('handleList', () => {
     test('throws when server is missing from argv and env', async () => {
         delete process.env.INSTANA_SERVER;
 
-        const argv = { token: 'test-token', type: baseArgv.type, resource: 'configuration' };
+        const argv = { token: 'test-token', type: baseArgv.type };
         await expect(handleList(argv)).rejects.toThrow(
             'Missing server. Specify --server or set INSTANA_SERVER'
         );
@@ -72,7 +71,7 @@ describe('handleList', () => {
     test('throws when token is missing from argv and env', async () => {
         delete process.env.INSTANA_API_TOKEN;
 
-        const argv = { server: 'localhost:8080', type: baseArgv.type, resource: 'configuration' };
+        const argv = { server: 'localhost:8080', type: baseArgv.type };
         await expect(handleList(argv)).rejects.toThrow(
             'Missing API token. Specify --token or set INSTANA_API_TOKEN'
         );

--- a/tools/fleet/src/__tests__/handlers/list.test.ts
+++ b/tools/fleet/src/__tests__/handlers/list.test.ts
@@ -106,6 +106,23 @@ describe('handleList', () => {
         expect(logger.debug).toHaveBeenCalledWith(
             JSON.stringify([{ id: 'cfg-1' }], null, 2)
         );
+        expect(logger.info).not.toHaveBeenCalledWith(
+            JSON.stringify([{ id: 'cfg-1' }], null, 2)
+        );
+    });
+
+    test('logs info response when isDebugEnabled returns false', async () => {
+        const getMock = jest.fn().mockResolvedValue({ data: [{ id: 'cfg-1' }] });
+        mockedAxios.create.mockReturnValue({ get: getMock } as any);
+        const logger = require('../../logger');
+        logger.isDebugEnabled.mockReturnValue(false);
+
+        await handleList(baseArgv);
+
+        expect(logger.info).toHaveBeenCalledWith(
+            JSON.stringify([{ id: 'cfg-1' }], null, 2)
+        );
+        expect(logger.debug).not.toHaveBeenCalled();
     });
 
     test('logs error and rethrows on HTTP error response', async () => {

--- a/tools/fleet/src/__tests__/handlers/list.test.ts
+++ b/tools/fleet/src/__tests__/handlers/list.test.ts
@@ -1,0 +1,143 @@
+import axios from 'axios';
+import { handleList } from '../../handlers/list';
+
+jest.mock('axios');
+jest.mock('../../logger', () => ({
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    level: 'info',
+    isDebugEnabled: jest.fn(() => false)
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('handleList', () => {
+    const baseArgv = {
+        server: 'localhost:8080',
+        token: 'test-token',
+        type: 'com.ibm.instana.customcollector',
+        resource: 'configuration',
+        debug: false
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        process.env.INSTANA_SERVER = 'localhost:8080';
+        process.env.INSTANA_API_TOKEN = 'test-token';
+
+        mockedAxios.create.mockReturnValue({
+            get: jest.fn()
+        } as any);
+    });
+
+    test('successfully lists configurations', async () => {
+        const getMock = jest.fn().mockResolvedValue({
+            data: [{ id: 'cfg-1', name: 'my-config' }]
+        });
+        mockedAxios.create.mockReturnValue({ get: getMock } as any);
+
+        const result = await handleList(baseArgv);
+
+        expect(getMock).toHaveBeenCalledTimes(1);
+        const [url, config] = getMock.mock.calls[0];
+        expect(url).toBe('http://localhost:8080/api/fleet/configurations');
+        expect(config.params).toEqual({ type: 'com.ibm.instana.customcollector' });
+        expect(config.headers['Authorization']).toBe('apiToken test-token');
+        expect(result).toEqual([{ id: 'cfg-1', name: 'my-config' }]);
+    });
+
+    test('uses environment variables when server/token not in argv', async () => {
+        const getMock = jest.fn().mockResolvedValue({
+            data: [{ id: 'cfg-2' }]
+        });
+        mockedAxios.create.mockReturnValue({ get: getMock } as any);
+
+        const argv = { type: baseArgv.type, resource: 'configuration', debug: false };
+        const result = await handleList(argv);
+
+        expect(result).toEqual([{ id: 'cfg-2' }]);
+        expect(getMock).toHaveBeenCalled();
+    });
+
+    test('throws when server is missing from argv and env', async () => {
+        delete process.env.INSTANA_SERVER;
+
+        const argv = { token: 'test-token', type: baseArgv.type, resource: 'configuration' };
+        await expect(handleList(argv)).rejects.toThrow(
+            'Missing server. Specify --server or set INSTANA_SERVER'
+        );
+    });
+
+    test('throws when token is missing from argv and env', async () => {
+        delete process.env.INSTANA_API_TOKEN;
+
+        const argv = { server: 'localhost:8080', type: baseArgv.type, resource: 'configuration' };
+        await expect(handleList(argv)).rejects.toThrow(
+            'Missing API token. Specify --token or set INSTANA_API_TOKEN'
+        );
+    });
+
+    test('throws when type is missing', async () => {
+        const argv = { ...baseArgv, type: undefined };
+        await expect(handleList(argv)).rejects.toThrow(
+            'Missing required parameter: --type'
+        );
+    });
+
+    test('sets debug log level when debug flag is true', async () => {
+        const getMock = jest.fn().mockResolvedValue({ data: [] });
+        mockedAxios.create.mockReturnValue({ get: getMock } as any);
+        const logger = require('../../logger');
+
+        await handleList({ ...baseArgv, debug: true });
+
+        expect(logger.level).toBe('debug');
+    });
+
+    test('logs debug response when isDebugEnabled returns true', async () => {
+        const getMock = jest.fn().mockResolvedValue({ data: [{ id: 'cfg-1' }] });
+        mockedAxios.create.mockReturnValue({ get: getMock } as any);
+        const logger = require('../../logger');
+        logger.isDebugEnabled.mockReturnValue(true);
+
+        await handleList(baseArgv);
+
+        expect(logger.debug).toHaveBeenCalledWith(
+            JSON.stringify([{ id: 'cfg-1' }], null, 2)
+        );
+    });
+
+    test('logs error and rethrows on HTTP error response', async () => {
+        const axiosError = Object.assign(new Error('Bad Request'), {
+            isAxiosError: true,
+            response: { data: { message: 'bad request' } }
+        });
+        const getMock = jest.fn().mockRejectedValue(axiosError);
+        mockedAxios.create.mockReturnValue({ get: getMock } as any);
+        mockedAxios.isAxiosError.mockReturnValue(true);
+
+        await expect(handleList(baseArgv)).rejects.toThrow('Bad Request');
+    });
+
+    test('logs error and rethrows on network error', async () => {
+        const networkError = Object.assign(new Error('Network Error'), {
+            isAxiosError: true,
+            response: undefined
+        });
+        const getMock = jest.fn().mockRejectedValue(networkError);
+        mockedAxios.create.mockReturnValue({ get: getMock } as any);
+        mockedAxios.isAxiosError.mockReturnValue(true);
+
+        await expect(handleList(baseArgv)).rejects.toThrow('Network Error');
+    });
+
+    test('logs error and rethrows on non-axios error', async () => {
+        const plainError = new Error('Something unexpected');
+        const getMock = jest.fn().mockRejectedValue(plainError);
+        mockedAxios.create.mockReturnValue({ get: getMock } as any);
+        mockedAxios.isAxiosError.mockReturnValue(false);
+
+        await expect(handleList(baseArgv)).rejects.toThrow('Something unexpected');
+    });
+});

--- a/tools/fleet/src/__tests__/utils.test.ts
+++ b/tools/fleet/src/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { parseTags, handleAxiosError, sendAgentRequest } from '../utils';
+import { parseTags, handleAxiosError, resolveConnection, sendAgentRequest } from '../utils';
 
 jest.mock('axios');
 jest.mock('../logger', () => ({
@@ -93,6 +93,53 @@ describe('handleAxiosError', () => {
         expect(logger.error).toHaveBeenCalledWith(
             expect.stringContaining('Something unexpected')
         );
+    });
+});
+
+describe('resolveConnection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        process.env.INSTANA_SERVER = 'localhost:8080';
+        process.env.INSTANA_API_TOKEN = 'test-token';
+    });
+
+    it('returns server, token and type from argv', () => {
+        const result = resolveConnection({
+            server: 'myserver.com',
+            token: 'mytoken',
+            type: 'com.ibm.instana.agent',
+            debug: false
+        });
+        expect(result).toEqual({ server: 'myserver.com', token: 'mytoken', type: 'com.ibm.instana.agent' });
+    });
+
+    it('falls back to env vars for server and token', () => {
+        const result = resolveConnection({ type: 'com.ibm.instana.agent' });
+        expect(result.server).toBe('localhost:8080');
+        expect(result.token).toBe('test-token');
+    });
+
+    it('throws when server is missing from argv and env', () => {
+        delete process.env.INSTANA_SERVER;
+        expect(() => resolveConnection({ token: 'x', type: 'y' }))
+            .toThrow('Missing server. Specify --server or set INSTANA_SERVER');
+    });
+
+    it('throws when token is missing from argv and env', () => {
+        delete process.env.INSTANA_API_TOKEN;
+        expect(() => resolveConnection({ server: 'localhost', type: 'y' }))
+            .toThrow('Missing API token. Specify --token or set INSTANA_API_TOKEN');
+    });
+
+    it('throws when type is missing', () => {
+        expect(() => resolveConnection({ server: 'localhost', token: 'x' }))
+            .toThrow('Missing required parameter: --type');
+    });
+
+    it('sets debug log level when debug flag is true', () => {
+        const logger = require('../logger');
+        resolveConnection({ server: 'localhost', token: 'x', type: 'y', debug: true });
+        expect(logger.level).toBe('debug');
     });
 });
 

--- a/tools/fleet/src/cli.ts
+++ b/tools/fleet/src/cli.ts
@@ -92,7 +92,7 @@ export function configureCLI(handlers: {
             }, handlers.handleRestart)
         .command(
             'list',
-            'list available resources',
+            'List available resources',
             (yargs) => {
                 return yargs
                     .option('server', {

--- a/tools/fleet/src/cli.ts
+++ b/tools/fleet/src/cli.ts
@@ -39,9 +39,9 @@ Update the agent configuration:
 const examplesForList = `
 Examples:
 
-List available resources:
-  ${execName} list --server example.com --token validToken --type agentType --resource configuration
-  ${execName} list --type agentType --resource configuration (specify the server and token as environment variables using INSTANA_SERVER and INSTANA_API_TOKEN)
+List configurations:
+  ${execName} list-configs --server example.com --token validToken --type agentType
+  ${execName} list-configs --type agentType (specify the server and token as environment variables using INSTANA_SERVER and INSTANA_API_TOKEN)
 `;
 
 export function configureCLI(handlers: {
@@ -91,8 +91,8 @@ export function configureCLI(handlers: {
                     .epilog(examplesForRestart);
             }, handlers.handleRestart)
         .command(
-            'list',
-            'List available resources',
+            'list-configs',
+            'List configurations',
             (yargs) => {
                 return yargs
                     .option('server', {
@@ -111,13 +111,6 @@ export function configureCLI(handlers: {
                         alias: 'y',
                         describe: 'Agent type, allowed values (com.ibm.opentelemetrycollector, com.ibm.instana.agent, com.ibm.instana.customcollector)',
                         type: 'string',
-                        demandOption: true
-                    })
-                    .option('resource', {
-                        alias: 'r',
-                        describe: 'Resource to list, allowed values (configuration)',
-                        type: 'string',
-                        choices: ['configuration'],
                         demandOption: true
                     })
                     .option('debug', {

--- a/tools/fleet/src/cli.ts
+++ b/tools/fleet/src/cli.ts
@@ -36,10 +36,19 @@ Update the agent configuration:
   ${execName} config-update --type agentType --tag key1=value1 --configuration-id=configID --debug
 `;
 
+const examplesForList = `
+Examples:
+
+List available resources:
+  ${execName} list --server example.com --token validToken --type agentType --resource configuration
+  ${execName} list --type agentType --resource configuration (specify the server and token as environment variables using INSTANA_SERVER and INSTANA_API_TOKEN)
+`;
+
 export function configureCLI(handlers: {
     handleRestart: (argv: any) => Promise<void>;
     handleDeploy: (argv: any) => Promise<void>;
     handleUpdate: (argv: any) => Promise<void>;
+    handleList: (argv: any) => Promise<void>;
 }) {
     return yargs
         .wrap(160)
@@ -81,6 +90,44 @@ export function configureCLI(handlers: {
                     })
                     .epilog(examplesForRestart);
             }, handlers.handleRestart)
+        .command(
+            'list',
+            'list available resources',
+            (yargs) => {
+                return yargs
+                    .option('server', {
+                        alias: 'S',
+                        describe: 'Address of an environment',
+                        type: 'string',
+                        demandOption: false
+                    })
+                    .option('token', {
+                        alias: 't',
+                        describe: 'API token for authenticating agent requests',
+                        type: 'string',
+                        demandOption: false
+                    })
+                    .option('type', {
+                        alias: 'y',
+                        describe: 'Agent type, allowed values (com.ibm.opentelemetrycollector, com.ibm.instana.agent, com.ibm.instana.customcollector)',
+                        type: 'string',
+                        demandOption: true
+                    })
+                    .option('resource', {
+                        alias: 'r',
+                        describe: 'Resource to list, allowed values (configuration)',
+                        type: 'string',
+                        choices: ['configuration'],
+                        demandOption: true
+                    })
+                    .option('debug', {
+                        alias: 'd',
+                        describe: 'Enable debug mode',
+                        type: 'boolean',
+                        default: false
+                    })
+                    .epilog(examplesForList);
+            }, handlers.handleList)
         .command(
             'deploy',
             'Deploy the agent component',

--- a/tools/fleet/src/cli.ts
+++ b/tools/fleet/src/cli.ts
@@ -31,9 +31,9 @@ const examplesForUpdate = `
 Examples:
 
 Update the agent configuration:
-  ${execName} config-update --server example.com --token validToken --type agentType --tag key1=value1 --tag key2=value2 --configuration-id=configID
-  ${execName} config-update --type agentType --tag key1=value1 --configuration-id=configID (specify the server and token as environment variables using INSTANA_SERVER and INSTANA_API_TOKEN)
-  ${execName} config-update --type agentType --tag key1=value1 --configuration-id=configID --debug
+  ${execName} update-config --server example.com --token validToken --type agentType --tag key1=value1 --tag key2=value2 --configuration-id=configID
+  ${execName} update-config --type agentType --tag key1=value1 --configuration-id=configID (specify the server and token as environment variables using INSTANA_SERVER and INSTANA_API_TOKEN)
+  ${execName} update-config --type agentType --tag key1=value1 --configuration-id=configID --debug
 `;
 
 const examplesForList = `
@@ -172,7 +172,7 @@ export function configureCLI(handlers: {
                     .epilog(examplesForDeploy);
             }, handlers.handleDeploy)
         .command(
-            'config-update',
+            'update-config',
             'Update the agent configuration',
             (yargs) => {
                 return yargs

--- a/tools/fleet/src/handlers/list.ts
+++ b/tools/fleet/src/handlers/list.ts
@@ -4,34 +4,32 @@ import logger from '../logger';
 export async function handleList(argv: any) {
     const { server, token, type } = resolveConnection(argv);
 
-    if (argv.resource === 'configuration') {
-        const axiosInstance = createAxiosInstance();
-        const url = `http://${server}/api/fleet/configurations`;
+    const axiosInstance = createAxiosInstance();
+    const url = `http://${server}/api/fleet/configurations`;
 
-        try {
-            logger.info(`Listing configurations for type: ${type}...`);
+    try {
+        logger.info(`Listing configurations for type: ${type}...`);
 
-            const response = await axiosInstance.get(url, {
-                params: { type },
-                headers: {
-                    // Content-Type is intentionally omitted: GET requests have no body
-                    'Authorization': `apiToken ${token}`
-                }
-            });
-
-            const data = response.data;
-
-            if (logger.isDebugEnabled()) {
-                logger.debug(JSON.stringify(data, null, 2));
-            } else {
-                logger.info(JSON.stringify(data, null, 2));
+        const response = await axiosInstance.get(url, {
+            params: { type },
+            headers: {
+                // Content-Type is intentionally omitted: GET requests have no body
+                'Authorization': `apiToken ${token}`
             }
+        });
 
-            return data;
+        const data = response.data;
 
-        } catch (error: any) {
-            handleAxiosError(error, 'list configurations');
-            throw error;
+        if (logger.isDebugEnabled()) {
+            logger.debug(JSON.stringify(data, null, 2));
+        } else {
+            logger.info(JSON.stringify(data, null, 2));
         }
+
+        return data;
+
+    } catch (error: any) {
+        handleAxiosError(error, 'list configurations');
+        throw error;
     }
 }

--- a/tools/fleet/src/handlers/list.ts
+++ b/tools/fleet/src/handlers/list.ts
@@ -1,31 +1,10 @@
-import { createAxiosInstance, handleAxiosError } from '../utils';
-import { validateServerAddress } from '../validators';
+import { createAxiosInstance, handleAxiosError, resolveConnection } from '../utils';
 import logger from '../logger';
 
 export async function handleList(argv: any) {
-    const server = argv.server ?? process.env.INSTANA_SERVER;
-    if (!server) {
-        throw new Error('Missing server. Specify --server or set INSTANA_SERVER');
-    }
+    const { server, token, type } = resolveConnection(argv);
 
-    const token = argv.token ?? process.env.INSTANA_API_TOKEN;
-    if (!token) {
-        throw new Error('Missing API token. Specify --token or set INSTANA_API_TOKEN');
-    }
-
-    if (argv.debug) {
-        logger.level = 'debug';
-    }
-
-    validateServerAddress(server);
-
-    const { type, resource } = argv;
-
-    if (!type) {
-        throw new Error('Missing required parameter: --type');
-    }
-
-    if (resource === 'configuration') {
+    if (argv.resource === 'configuration') {
         const axiosInstance = createAxiosInstance();
         const url = `http://${server}/api/fleet/configurations`;
 
@@ -35,6 +14,7 @@ export async function handleList(argv: any) {
             const response = await axiosInstance.get(url, {
                 params: { type },
                 headers: {
+                    // Content-Type is intentionally omitted: GET requests have no body
                     'Authorization': `apiToken ${token}`
                 }
             });
@@ -43,9 +23,9 @@ export async function handleList(argv: any) {
 
             if (logger.isDebugEnabled()) {
                 logger.debug(JSON.stringify(data, null, 2));
+            } else {
+                logger.info(JSON.stringify(data, null, 2));
             }
-
-            logger.info(JSON.stringify(data, null, 2));
 
             return data;
 

--- a/tools/fleet/src/handlers/list.ts
+++ b/tools/fleet/src/handlers/list.ts
@@ -1,0 +1,57 @@
+import { createAxiosInstance, handleAxiosError } from '../utils';
+import { validateServerAddress } from '../validators';
+import logger from '../logger';
+
+export async function handleList(argv: any) {
+    const server = argv.server ?? process.env.INSTANA_SERVER;
+    if (!server) {
+        throw new Error('Missing server. Specify --server or set INSTANA_SERVER');
+    }
+
+    const token = argv.token ?? process.env.INSTANA_API_TOKEN;
+    if (!token) {
+        throw new Error('Missing API token. Specify --token or set INSTANA_API_TOKEN');
+    }
+
+    if (argv.debug) {
+        logger.level = 'debug';
+    }
+
+    validateServerAddress(server);
+
+    const { type, resource } = argv;
+
+    if (!type) {
+        throw new Error('Missing required parameter: --type');
+    }
+
+    if (resource === 'configuration') {
+        const axiosInstance = createAxiosInstance();
+        const url = `http://${server}/api/fleet/configurations`;
+
+        try {
+            logger.info(`Listing configurations for type: ${type}...`);
+
+            const response = await axiosInstance.get(url, {
+                params: { type },
+                headers: {
+                    'Authorization': `apiToken ${token}`
+                }
+            });
+
+            const data = response.data;
+
+            if (logger.isDebugEnabled()) {
+                logger.debug(JSON.stringify(data, null, 2));
+            }
+
+            logger.info(JSON.stringify(data, null, 2));
+
+            return data;
+
+        } catch (error: any) {
+            handleAxiosError(error, 'list configurations');
+            throw error;
+        }
+    }
+}

--- a/tools/fleet/src/index.ts
+++ b/tools/fleet/src/index.ts
@@ -2,13 +2,13 @@
 
 import { configureCLI } from './cli';
 import { handleDeploy } from './handlers/deploy';
+import { handleList } from './handlers/list';
 import { handleRestart } from './handlers/restart';
 import { handleUpdate } from './handlers/update';
-import logger from './logger';
-
 // Wire CLI commands
 configureCLI({
     handleRestart,
     handleDeploy,
-    handleUpdate
+    handleUpdate,
+    handleList
 });

--- a/tools/fleet/src/utils.ts
+++ b/tools/fleet/src/utils.ts
@@ -51,14 +51,11 @@ export function handleAxiosError(error: any, context: string): void {
 }
 
 /**
- * Shared handler logic for all agent control actions (restart, deploy, config-update).
- * Resolves server/token, validates inputs, builds and sends the POST request.
+ * Resolves and validates the common connection parameters (server, token, type, debug)
+ * shared across all fleet commands. Extracted to avoid duplication between sendAgentRequest
+ * and other handlers (e.g. handleList) that cannot reuse sendAgentRequest directly.
  */
-export async function sendAgentRequest(
-    action: string,
-    argv: any,
-    configurationId?: string
-): Promise<any> {
+export function resolveConnection(argv: any): { server: string; token: string; type: string } {
     const server = argv.server ?? process.env.INSTANA_SERVER;
     if (!server) {
         throw new Error('Missing server. Specify --server or set INSTANA_SERVER');
@@ -80,7 +77,21 @@ export async function sendAgentRequest(
         throw new Error('Missing required parameter: --type');
     }
 
-    const tagsInput = [].concat(argv.tag ?? []).filter(Boolean);
+    return { server, token, type };
+}
+
+/**
+ * Shared handler logic for all agent control actions (restart, deploy, config-update).
+ * Resolves server/token, validates inputs, builds and sends the POST request.
+ */
+export async function sendAgentRequest(
+    action: string,
+    argv: any,
+    configurationId?: string
+): Promise<any> {
+    const { server, token, type } = resolveConnection(argv);
+
+    const tagsInput: string[] = [].concat(argv.tag ?? []).filter(Boolean);
     if (tagsInput.length === 0) {
         throw new Error('Missing required parameter: --tag (at least one tag is required)');
     }

--- a/tools/fleet/src/utils.ts
+++ b/tools/fleet/src/utils.ts
@@ -81,7 +81,7 @@ export function resolveConnection(argv: any): { server: string; token: string; t
 }
 
 /**
- * Shared handler logic for all agent control actions (restart, deploy, config-update).
+ * Shared handler logic for all agent control actions (restart, deploy, update-config).
  * Resolves server/token, validates inputs, builds and sends the POST request.
  */
 export async function sendAgentRequest(


### PR DESCRIPTION
**Command syntax:**

`stanctl-fleet list --resource configuration --server <server> --token <token> --type <agent-type>`

The `list` command calls the appropriate API based on the `--resource` option. Currently, only `configuration` is supported as a resource type.

This command lists all available configurations, making it easy to obtain the `configuration-id` required for the `deploy` and `update-config` commands.
