### PR TITLE
stanctl-integration: import command

### DIFF
--- a/tools/integration/src/__tests__/cli.test.ts
+++ b/tools/integration/src/__tests__/cli.test.ts
@@ -190,6 +190,34 @@ describe('CLI Module', () => {
             expect(cliContent).toContain("alias: 'd'");
         });
 
+        it('should define import collector options', async () => {
+            const fs = require('fs');
+            const path = require('path');
+            const cliPath = path.join(__dirname, '../cli.ts');
+            const cliContent = fs.readFileSync(cliPath, 'utf-8');
+
+            // Verify collector-specific options exist
+            expect(cliContent).toContain("'name'");
+            expect(cliContent).toContain("'config-version'");
+            expect(cliContent).toContain("'type'");
+            expect(cliContent).toContain("'config-input'");
+            expect(cliContent).toContain("alias: 'n'");
+            expect(cliContent).toContain("alias: 'r'");
+            expect(cliContent).toContain("alias: 'y'");
+            expect(cliContent).toContain("alias: 'c'");
+        });
+
+        it('should define import collector conditional validation', async () => {
+            const fs = require('fs');
+            const path = require('path');
+            const cliPath = path.join(__dirname, '../cli.ts');
+            const cliContent = fs.readFileSync(cliPath, 'utf-8');
+
+            // Verify .check() enforces --include collector conditional required options
+            expect(cliContent).toContain("argv['include'] === 'collector'");
+            expect(cliContent).toContain("--include collector requires:");
+        });
+
         it('should define export command options', async () => {
             const fs = require('fs');
             const path = require('path');

--- a/tools/integration/src/__tests__/handlers/import.test.ts
+++ b/tools/integration/src/__tests__/handlers/import.test.ts
@@ -1215,4 +1215,162 @@ describe('handleImport', () => {
             expect(mockedLogger.info).toHaveBeenCalledWith(expect.stringContaining('Failed: 1'));
         });
     });
+
+    describe('Collector Import', () => {
+        const collectorArgv = {
+            server: 'test-server.com',
+            token: 'test-token',
+            include: 'collector',
+            name: 'my-collector',
+            'config-version': '1.0',
+            type: 'com.ibm.instana.customcollector',
+            package: '/test/package',
+            'config-input': '/test/config-dir',
+            location: '/test/location',
+            debug: false
+        };
+
+        const configJson = {
+            image: {
+                registry: 'quay.io',
+                repository: 'instana-collectors/my-collector',
+                tag: '1.0.0'
+            }
+        };
+
+        beforeEach(() => {
+            mockedValidators.validateServerAddress = jest.fn();
+        });
+
+        it('should import customcollector with files and image from config.json', async () => {
+            mockedFs.existsSync = jest.fn().mockReturnValue(true);
+            jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true, isFile: () => true } as any);
+            // config-input contains only endpoint yaml files (no config.json)
+            mockedFs.readdirSync = jest.fn().mockReturnValue(['cassandra.yaml', 'postgres.yaml'] as any);
+            mockedFs.readFileSync = jest.fn()
+                .mockReturnValueOnce(Buffer.from('cassandra-content'))   // cassandra.yaml
+                .mockReturnValueOnce(Buffer.from('postgres-content'))    // postgres.yaml
+                .mockReturnValueOnce(JSON.stringify(configJson));        // package/collector/config.json
+
+            mockAxiosInstance.post.mockResolvedValue({ status: 201 });
+
+            await handleImport(collectorArgv);
+
+            expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+                expect.stringContaining('/api/fleet/configurations?type=com.ibm.instana.customcollector'),
+                {
+                    name: 'my-collector',
+                    version: '1.0',
+                    type: 'com.ibm.instana.customcollector',
+                    configuration: {
+                        files: [
+                            { name: 'cassandra.yaml', data: Buffer.from('cassandra-content').toString('base64') },
+                            { name: 'postgres.yaml', data: Buffer.from('postgres-content').toString('base64') }
+                        ],
+                        image: { repo: 'quay.io/instana-collectors/my-collector:1.0.0' }
+                    }
+                },
+                expect.any(Object)
+            );
+            expect(mockedLogger.info).toHaveBeenCalledWith(expect.stringContaining('Using image: quay.io/instana-collectors/my-collector:1.0.0'));
+            expect(mockedLogger.info).toHaveBeenCalledWith(expect.stringContaining('Successfully imported collector configuration'));
+        });
+
+        it('should import non-customcollector without image block', async () => {
+            const argv = { ...collectorArgv, type: 'com.ibm.instana.agent' };
+
+            mockedFs.existsSync = jest.fn().mockReturnValue(true);
+            jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true, isFile: () => true } as any);
+            mockedFs.readdirSync = jest.fn().mockReturnValue(['agent-config.yaml'] as any);
+            mockedFs.readFileSync = jest.fn().mockReturnValueOnce(Buffer.from('agent-content'));
+
+            mockAxiosInstance.post.mockResolvedValue({ status: 201 });
+
+            await handleImport(argv);
+
+            expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+                expect.stringContaining('/api/fleet/configurations?type=com.ibm.instana.agent'),
+                {
+                    name: 'my-collector',
+                    version: '1.0',
+                    type: 'com.ibm.instana.agent',
+                    configuration: {
+                        files: [
+                            { name: 'agent-config.yaml', data: Buffer.from('agent-content').toString('base64') }
+                        ]
+                    }
+                },
+                expect.any(Object)
+            );
+            expect(mockAxiosInstance.post.mock.calls[0][1].configuration.image).toBeUndefined();
+        });
+
+        it('should exit if config-input path does not exist', async () => {
+            mockedFs.existsSync = jest.fn().mockReturnValue(false);
+
+            await expect(handleImport(collectorArgv)).rejects.toThrow('process.exit(1)');
+            expect(mockedLogger.error).toHaveBeenCalledWith(expect.stringContaining('Config input path does not exist'));
+        });
+
+        it('should exit if config-input is not a directory', async () => {
+            mockedFs.existsSync = jest.fn().mockReturnValue(true);
+            jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => false } as any);
+
+            await expect(handleImport(collectorArgv)).rejects.toThrow('process.exit(1)');
+            expect(mockedLogger.error).toHaveBeenCalledWith(expect.stringContaining('not a directory'));
+        });
+
+        it('should exit if config-input directory is empty', async () => {
+            mockedFs.existsSync = jest.fn().mockReturnValue(true);
+            jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true, isFile: () => true } as any);
+            mockedFs.readdirSync = jest.fn().mockReturnValue([] as any);
+
+            await expect(handleImport(collectorArgv)).rejects.toThrow('process.exit(1)');
+            expect(mockedLogger.error).toHaveBeenCalledWith(expect.stringContaining('No files found'));
+        });
+
+        it('should exit if config.json is missing for customcollector', async () => {
+            mockedFs.existsSync = jest.fn()
+                .mockReturnValueOnce(true)   // package path exists
+                .mockReturnValueOnce(true)   // config-input dir exists
+                .mockReturnValueOnce(false); // package/collector/config.json does not exist
+            jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true, isFile: () => true } as any);
+            mockedFs.readdirSync = jest.fn().mockReturnValue(['cassandra.yaml'] as any);
+            mockedFs.readFileSync = jest.fn().mockReturnValueOnce(Buffer.from('content'));
+
+            await expect(handleImport(collectorArgv)).rejects.toThrow('process.exit(1)');
+            expect(mockedLogger.error).toHaveBeenCalledWith(expect.stringContaining('config.json not found'));
+        });
+
+        it('should exit if config.json is missing image fields', async () => {
+            mockedFs.existsSync = jest.fn().mockReturnValue(true);
+            jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true, isFile: () => true } as any);
+            // config-input has only yaml files; config.json is in the package
+            mockedFs.readdirSync = jest.fn().mockReturnValue(['cassandra.yaml'] as any);
+            mockedFs.readFileSync = jest.fn()
+                .mockReturnValueOnce(Buffer.from('content'))              // cassandra.yaml
+                .mockReturnValueOnce(JSON.stringify({ image: {} }));      // package/collector/config.json — missing fields
+
+            await expect(handleImport(collectorArgv)).rejects.toThrow('process.exit(1)');
+            expect(mockedLogger.error).toHaveBeenCalledWith(expect.stringContaining('missing required image fields'));
+        });
+
+        it('should exit and log error on API failure', async () => {
+            mockedFs.existsSync = jest.fn().mockReturnValue(true);
+            jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true, isFile: () => true } as any);
+            mockedFs.readdirSync = jest.fn().mockReturnValue(['cassandra.yaml'] as any);
+            mockedFs.readFileSync = jest.fn()
+                .mockReturnValueOnce(Buffer.from('content'))         // cassandra.yaml
+                .mockReturnValueOnce(JSON.stringify(configJson));    // package/collector/config.json
+
+            const apiError: any = new Error('API Error');
+            apiError.response = { status: 500, data: { message: 'Internal Server Error' } };
+            (mockedAxios.isAxiosError as any) = jest.fn().mockReturnValue(true);
+            mockAxiosInstance.post.mockRejectedValue(apiError);
+
+            await expect(handleImport(collectorArgv)).rejects.toThrow('process.exit(1)');
+            expect(mockedLogger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to import collector configuration'));
+            expect(mockedLogger.error).toHaveBeenCalledWith(expect.stringContaining('500'));
+        });
+    });
 });

--- a/tools/integration/src/cli.ts
+++ b/tools/integration/src/cli.ts
@@ -21,10 +21,13 @@ const examplesForImport = `
 Examples:
 
 Import integration package with parameters replaced:
-  ${execName} import --package my-package --server example.com --include "dashboards/**/test-*.json" --set key1=value1 --set key2=value2
-  ${execName} import --package my-package --server example.com --include "events/**/*.json"
-  ${execName} import --package my-package --server example.com --include "entities/**/*.json"
-  ${execName} import --package my-package --server example.com --include "smart-alerts/**/*.json"
+  ${execName} import --package my-package --server example.com --token mytoken --include "dashboards/**/test-*.json" --set key1=value1 --set key2=value2
+  ${execName} import --package my-package --server example.com --token mytoken --include "events/**/*.json"
+  ${execName} import --package my-package --server example.com --token mytoken --include "entities/**/*.json"
+  ${execName} import --package my-package --server example.com --token mytoken --include "smart-alerts/**/*.json"
+
+Import collector configuration:
+  ${execName} import --package my-package --server example.com --token mytoken --include collector --name <configurationName> --type <instanaAgent/idot/customcollector> --config-version <version> --config-input <path-to-directory>
 `;
 
 const examplesForExport = `
@@ -124,7 +127,7 @@ export function configureCLI(handlers: {
                 })
                 .option('include', {
                     alias: 'i',
-                    describe: 'Folder or pattern to match integration element files to include',
+                    describe: 'Folder or pattern to match integration element files to include, or "collector" to import a collector configuration',
                     type: 'string',
                     demandOption: false
                 })
@@ -139,6 +142,42 @@ export function configureCLI(handlers: {
                     describe: 'Enable debug mode',
                     type: 'boolean',
                     default: false
+                })
+                .option('name', {
+                    alias: 'n',
+                    describe: 'Configuration name',
+                    type: 'string',
+                    demandOption: false
+                })
+                .option('config-version', {
+                    alias: 'r',
+                    describe: 'Configuration version',
+                    type: 'string',
+                    demandOption: false
+                })
+                .option('type', {
+                    alias: 'y',
+                    describe: 'Agent type, allowed values (com.ibm.opentelemetrycollector, com.ibm.instana.agent, com.ibm.instana.customcollector)',
+                    type: 'string',
+                    demandOption: false
+                })
+                .option('config-input', {
+                    alias: 'c',
+                    describe: 'Path to directory containing collector configuration files to upload',
+                    type: 'string',
+                    demandOption: false
+                })
+                .check((argv) => {
+                    if (argv['include'] === 'collector') {
+                        const collectorFields = ['name', 'config-version', 'type', 'config-input'];
+                        const missing = collectorFields.filter(f => argv[f] === undefined);
+                        if (missing.length > 0) {
+                            throw new Error(
+                                `--include collector requires: ${missing.map(f => `--${f}`).join(', ')}`
+                            );
+                        }
+                    }
+                    return true;
                 })
                 .epilog(examplesForImport);
         }, handlers.handleImport)

--- a/tools/integration/src/handlers/import.ts
+++ b/tools/integration/src/handlers/import.ts
@@ -13,6 +13,15 @@ Handlebars.registerHelper('default', function (value: string, defaultValue: stri
     return typeof value !== 'undefined' ? value : defaultValue;
 });
 
+// TODO: remove getCollectorBaseUrl once collector API is available on production HTTPS,
+// then uncomment the line below and delete the getCollectorBaseUrl call
+function getCollectorBaseUrl(server: string): string {
+    const portMatch = server.match(/:(\d+)$/);
+    const port = portMatch ? parseInt(portMatch[1], 10) : 443;
+    const protocol = port === 443 ? 'https' : 'http';
+    return `${protocol}://${server}`;
+}
+
 interface AccessRule {
     accessType: string;
     relationType: string;
@@ -22,7 +31,8 @@ interface AccessRule {
  * Handle import command - imports dashboards, events, and entities to Instana
  */
 export async function handleImport(argv: any) {
-    const { package: packageNameOrPath, server, token, location, include: includePattern, set: parameters, debug } = argv;
+    const { package: packageNameOrPath, server, token, location, include: includePattern, set: parameters, debug,
+            name, 'config-version': version, type: agentType, 'config-input': configInput } = argv;
 
     // Set log level to debug if the debug flag is set
     if (debug) {
@@ -37,6 +47,23 @@ export async function handleImport(argv: any) {
         process.exit(1);
     }
 
+    // Create an axios instance with a custom httpsAgent to ignore self-signed certificate errors
+    const axiosInstance = axios.create({
+        httpsAgent: new https.Agent({
+            rejectUnauthorized: false
+        })
+    });
+
+    // Collector mode — package provides config.json, config-input provides the files to upload
+    if (includePattern === 'collector') {
+        let resolvedPackagePath = packageNameOrPath;
+        if (!fs.existsSync(packageNameOrPath)) {
+            resolvedPackagePath = path.join(location, 'node_modules', packageNameOrPath);
+        }
+        await importCollectorConfiguration(server, token, name, version, agentType, configInput, resolvedPackagePath, axiosInstance);
+        return;
+    }
+
     let packagePath = packageNameOrPath;
     if (!fs.existsSync(packageNameOrPath)) {
         packagePath = path.join(location, 'node_modules', packageNameOrPath);
@@ -46,13 +73,6 @@ export async function handleImport(argv: any) {
     const defaultEventsFolders = ['events'];
     const defaultEntitiesFolders = ['entities'];
     const defaultSmartAlertsFolders = ['smart-alerts'];
-
-    // Create an axios instance with a custom httpsAgent to ignore self-signed certificate errors
-    const axiosInstance = axios.create({
-        httpsAgent: new https.Agent({
-            rejectUnauthorized: false
-        })
-    });
 
     async function importIntegration(searchPattern: string, apiPath: string, typeLabel: string, skipFiles: Set<string> = new Set()) {
         const files = globSync(searchPattern);
@@ -306,6 +326,81 @@ export async function handleImport(argv: any) {
             const searchPattern = path.join(packagePath, defaultFolder, '**/*.json');
             await importIntegration(searchPattern, "smart-alert", "smart alert");
         }
+    }
+}
+
+/**
+ * Import a collector configuration to Instana
+ */
+async function importCollectorConfiguration(server: string, token: string, name: string, version: string, agentType: string, configInput: string, packagePath: string, axiosInstance: any): Promise<void> {
+    logger.info(`Importing collector configuration "${name}" (type=${agentType}, version=${version}) from ${configInput} ...`);
+
+    if (!fs.existsSync(configInput)) {
+        logger.error(`Config input path does not exist: ${configInput}`);
+        process.exit(1);
+    }
+
+    const stat = fs.statSync(configInput);
+    if (!stat.isDirectory()) {
+        logger.error(`Config input path is not a directory: ${configInput}`);
+        process.exit(1);
+    }
+
+    const allFiles = fs.readdirSync(configInput).filter(f => fs.statSync(path.join(configInput, f)).isFile());
+    if (allFiles.length === 0) {
+        logger.error(`No files found in config input directory: ${configInput}`);
+        process.exit(1);
+    }
+
+    // All files from config-input are uploaded
+    const files = allFiles.map(f => ({
+        name: f,
+        data: fs.readFileSync(path.join(configInput, f)).toString('base64')
+    }));
+
+    logger.info(`Found ${files.length} config file(s): ${allFiles.join(', ')}`);
+
+    // Build configuration object - image block only for customcollector, read from package/collector/config.json
+    const configuration: any = { files };
+    if (agentType === 'com.ibm.instana.customcollector') {
+        const configJsonPath = path.join(packagePath, 'collector', 'config.json');
+        if (!fs.existsSync(configJsonPath)) {
+            logger.error(`config.json not found in ${configJsonPath} - required for type com.ibm.instana.customcollector`);
+            process.exit(1);
+        }
+        const configJson = JSON.parse(fs.readFileSync(configJsonPath, 'utf8'));
+        const { registry, repository, tag } = configJson.image ?? {};
+        if (!registry || !repository || !tag) {
+            logger.error(`config.json is missing required image fields: registry, repository, tag`);
+            process.exit(1);
+        }
+        configuration.image = { repo: `${registry}/${repository}:${tag}` };
+        logger.info(`Using image: ${configuration.image.repo}`);
+    }
+
+    const url = `${getCollectorBaseUrl(server)}/api/fleet/configurations?type=${agentType}`;
+    // const url = `${server}/api/fleet/configurations?type=${agentType}`;
+    logger.info(`Applying collector configuration to ${url} ...`);
+
+    try {
+        const response = await axiosInstance.post(url, { name, version, type: agentType, configuration }, {
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `apiToken ${token}`
+            }
+        });
+        logger.info(`Successfully imported collector configuration "${name}": ${response.status}`);
+    } catch (error) {
+        if (axios.isAxiosError(error)) {
+            logger.error(`Failed to import collector configuration: ${error.message}`);
+            if (error.response) {
+                logger.error(`Response data: ${JSON.stringify(error.response.data)}`);
+                logger.error(`Response status: ${error.response.status}`);
+            }
+        } else {
+            logger.error(`Failed to import collector configuration: ${String(error)}`);
+        }
+        process.exit(1);
     }
 }
 


### PR DESCRIPTION
New flags:

--name - configuration name
--type - agent type (com.ibm.instana.customcollector, com.ibm.instana.agent, com.ibm.opentelemetrycollector)
--config-version - configuration version
--config-input - path to directory containing collector config files


Usage:
`stanctl-integration import --server <server> --token <validToken --type <agentType> --name configNameTest --config-version 1.0.0 --config-input <path-to-config-files> --include collector --debug --package <packageName>`

What it does:
Reads all files from --config-input, base64-encodes them into configuration.files[]
For customcollector type, reads image metadata from <package>/collector/config.json and adds configuration.image.repo
POSTs to POST /api/fleet/configurations?type=<agentType>

